### PR TITLE
Removed local-quote dependency from transfer fund workers

### DIFF
--- a/src/main/java/org/mifos/connector/ams/interop/InteroperationRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/ams/interop/InteroperationRouteBuilder.java
@@ -105,6 +105,7 @@ public class InteroperationRouteBuilder extends ErrorHandlerRouteBuilder {
                 .id("send-transfers")
                 .log(LoggingLevel.INFO, "Sending transfer with action: ${exchangeProperty." + TRANSFER_ACTION + "} " +
                         " for transaction: ${exchangeProperty." + TRANSACTION_ID + "}")
+                .to("direct:get-external-account")
                 .process(prepareTransferRequest)
                 .process(pojoToString)
                 .process(amsService::sendTransfer)

--- a/src/main/java/org/mifos/connector/ams/zeebe/ZeebeeWorkers.java
+++ b/src/main/java/org/mifos/connector/ams/zeebe/ZeebeeWorkers.java
@@ -104,8 +104,11 @@ public class ZeebeeWorkers {
                                 TRANSACTION_ID,
                                 CHANNEL_REQUEST,
                                 TENANT_ID,
-                                EXTERNAL_ACCOUNT_ID,
                                 LOCAL_QUOTE_RESPONSE);
+
+                        TransactionChannelRequestDTO channelRequest = objectMapper.readValue(ex.getProperty(CHANNEL_REQUEST, String.class), TransactionChannelRequestDTO.class);
+                        ex.setProperty(PARTY_ID_TYPE, channelRequest.getPayer().getPartyIdInfo().getPartyIdType().name());
+                        ex.setProperty(PARTY_ID, channelRequest.getPayer().getPartyIdInfo().getPartyIdentifier());
                         ex.setProperty(TRANSFER_ACTION, PREPARE.name());
                         ex.setProperty(ZEEBE_JOB_KEY, job.getKey());
                         ex.setProperty(TRANSACTION_ROLE, TransactionRole.PAYER.name());
@@ -130,9 +133,12 @@ public class ZeebeeWorkers {
                                 TRANSACTION_ID,
                                 CHANNEL_REQUEST,
                                 TENANT_ID,
-                                EXTERNAL_ACCOUNT_ID,
                                 LOCAL_QUOTE_RESPONSE,
                                 TRANSFER_CODE);
+
+                        TransactionChannelRequestDTO channelRequest = objectMapper.readValue(ex.getProperty(CHANNEL_REQUEST, String.class), TransactionChannelRequestDTO.class);
+                        ex.setProperty(PARTY_ID_TYPE, channelRequest.getPayer().getPartyIdInfo().getPartyIdType().name());
+                        ex.setProperty(PARTY_ID, channelRequest.getPayer().getPartyIdInfo().getPartyIdentifier());
                         ex.setProperty(TRANSFER_ACTION, CREATE.name());
                         ex.setProperty(ZEEBE_JOB_KEY, job.getKey());
                         ex.setProperty(TRANSACTION_ROLE, TransactionRole.PAYER.name());
@@ -157,9 +163,12 @@ public class ZeebeeWorkers {
                                 TRANSACTION_ID,
                                 CHANNEL_REQUEST,
                                 TENANT_ID,
-                                EXTERNAL_ACCOUNT_ID,
                                 LOCAL_QUOTE_RESPONSE,
                                 TRANSFER_CODE);
+
+                        TransactionChannelRequestDTO channelRequest = objectMapper.readValue(ex.getProperty(CHANNEL_REQUEST, String.class), TransactionChannelRequestDTO.class);
+                        ex.setProperty(PARTY_ID_TYPE, channelRequest.getPayer().getPartyIdInfo().getPartyIdType().name());
+                        ex.setProperty(PARTY_ID, channelRequest.getPayer().getPartyIdInfo().getPartyIdentifier());
                         ex.setProperty(TRANSFER_ACTION, RELEASE.name());
                         ex.setProperty(ZEEBE_JOB_KEY, job.getKey());
                         ex.setProperty(TRANSACTION_ROLE, TransactionRole.PAYEE.name());


### PR DESCRIPTION
Currently, for book-fund, block-fund, and release-fund workers, requires EXTERNAL_ACCOUNT_ID and LOCAL_QUOTE_RESPONSE variables, which are obtained from WORKER_PAYER_LOCAL_QUOTE. 

There can be use cases where one might not want to add a local quote to transactions, to remove this dependency the following changes have been made:
- added get-external-account route in send-transfer route to obtain external account id for transaction
- added condition for fspFees and fspCommission to be added only when LOCAL_QUOTE_RESPONSE is not empty

Tested with and without local quote worker in BPMNs with Fin12 leopard instance.