### PR TITLE
Add github actions workflow to assemble project on push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,10 @@
+name: Test
+on: [push]
+jobs:
+  Assemble:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Assemble project
+        run: ./gradlew clean build

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ publishing {
     }
 }
 
+test {
+    useJUnitPlatform()
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }

--- a/src/main/java/org/mifos/connector/ams/interop/InteroperationRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/ams/interop/InteroperationRouteBuilder.java
@@ -1,7 +1,7 @@
 package org.mifos.connector.ams.interop;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;


### PR DESCRIPTION
This PR adds a github actions workflow that checks the project can be assembled in each push

It appears the code in master is broken due to a regression between #6 and #5 being merged in a different order - the first commit addresses this

As seen here:
workflow without fixing dep fails: https://github.com/afk11/ph-ee-connector-ams-mifos/actions/runs/1583166629
workflow after fixing dep passes: https://github.com/afk11/ph-ee-connector-ams-mifos/actions/runs/1583208849