### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM amazoncorretto:17-al2023-jdk
 # Disable caching to make the dnf upgrade effective (the build job passes the build time as the value of this argument)
 ARG CACHEBUST=1
 
+# Add a custom trusted root ca certificate to the image
+ARG CUSTOM_TRUSTED_ROOT_CA_CERTIFICATE_URL
+
 # Upgrade the system
 RUN dnf -y --releasever=latest --setopt=install_weak_deps=False upgrade && \
-# Add less, vi, nano, ps, ping, netstat, ss, traceroute, telnet (curl is already included in the image)
-    dnf -y --releasever=latest --setopt=install_weak_deps=False install less vim nano procps-ng iputils net-tools iproute traceroute telnet findutils && \
+# Add less, vi, nano, ps, ping, ss, traceroute, telnet, dig, find and unzip (curl is already included in the image)
+    dnf -y --releasever=latest --setopt=install_weak_deps=False install less vim nano procps-ng iputils iproute traceroute telnet bind-utils findutils unzip && \
 # Create the non-root user to run the application
     dnf -y --releasever=latest --setopt=install_weak_deps=False install shadow-utils && \
     groupadd --system --gid 1000 javagroup && \
@@ -17,8 +20,14 @@ RUN dnf -y --releasever=latest --setopt=install_weak_deps=False upgrade && \
     dnf -y clean all && \
     rm -rf /var/cache/dnf
 
+# Add the custom trusted root ca certificate
+RUN if [ -n "${CUSTOM_TRUSTED_ROOT_CA_CERTIFICATE_URL}" ]; then \
+        curl "${CUSTOM_TRUSTED_ROOT_CA_CERTIFICATE_URL}" -o "/etc/pki/ca-trust/source/anchors/${CUSTOM_TRUSTED_ROOT_CA_CERTIFICATE_URL##*/}" && \
+        update-ca-trust ; \
+    fi
+
 # Expose the application's listening port
-EXPOSE 5000 8080
+EXPOSE 8080
 
 # Add a healthcheck (note that this only works locally, Kubernetes explicitly disables this one)
 HEALTHCHECK CMD curl --fail http://localhost:8080/actuator/health || exit 1
@@ -31,4 +40,3 @@ USER javauser:javagroup
 
 # Run the application
 CMD java -jar *.jar
-


### PR DESCRIPTION
## Description

* Describe the changes made and why they were made.

Changes to the Dockerfile:

- remove unused exposed port 5000
- remove net-tools (netstat) from the installed packages as it grabs systemd as a dependency
- added bind-utils (dig) to the installed packages
- added unzip to the installed packages
- added CUSTOM_TRUSTED_ROOT_CA_CERTIFICATE_URL handling to the Dockerfile
