### PR TITLE
[GAZ-12] add docker buildx gazelle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
       - run:
           name: Build and Push Docker tag Image
           command: |
@@ -48,7 +48,7 @@ jobs:
       - checkout
       # Install Docker to build and push the image
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
 
       # Build the Docker image
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,14 @@ jobs:
           name: Sanitize Branch Name
           command: |
             echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV # Also ensure branch tag is lowercase
+      # First build and push with branch-latest tag
       - docker-buildx/build-and-push:
-          # Using lowercase variables defined above
           image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
           tag: "${SANITIZED_BRANCH}-latest"
+      # Then build and push with branch-version tag
+      - docker-buildx/build-and-push:
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "${SANITIZED_BRANCH}-${APP_VERSION}"
           # Add dockerhub credentials if needed
           # dockerhub-username: "$DOCKERHUB_USERNAME"
           # dockerhub-password: "$DOCKERHUB_PASSWORD"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - docker-buildx/build-and-push:
           # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
           image-name: "$IMAGE_NAME"
-          tag: "$IMAGE_TAG-gazelle"
+          tag: "$IMAGE_TAG"
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
           
       - docker-buildx/build-and-push:
           # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
-          image-name: $IMAGE_NAME
-          tag: $IMAGE_TAG
+          image-name: $CIRCLE_PROJECT_NAME
+          tag: $CIRCLE_TAG
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -66,7 +66,7 @@ jobs:
             ./gradlew clean bootJar
             
       - docker-buildx/build-and-push:
-          image-name: $IMAGE_NAME
+          image-name: $CIRCLE_PROJECT_NAME
           tag: "latest"
       # # Log in to DockerHub using environment variables
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  docker-buildx: devarsh/docker-buildx-orb@0.1.1
+
 executors:
   docker-executor:
     docker:
@@ -10,91 +13,86 @@ jobs:
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-      GITHUB_TOKEN: ${GITHUB_TOKEN}  # Add the GitHub token as an environment variable
-
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - docker-buildx/install
       - run:
-          name: Build and Push Docker tag Image
+          name: Check if Docker image tag exists
           command: |
-            # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
-
-            # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tags/$IMAGE_TAG" > /dev/null; then
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
+      - run:
+          name: Build Application
+          command: ./gradlew bootJar
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          tag: "$CIRCLE_TAG"
 
-            # Build and tag the Docker image
-            ./gradlew bootJar
-            docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
-
-            # Push the Docker image to Docker Hub
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
-
-          # when: always  # The job will be executed even if there's no match for the tag filter
+  build_and_push_branch_image:
+    executor: docker-executor
+    environment:
+      JVM_OPTS: -Xmx512m
+      TERM: dumb
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - docker-buildx/install
+      - run:
+          name: Build Application
+          command: |
+            ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+      - run:
+          name: Sanitize Branch Name
+          command: |
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/\//-/g')" >> $BASH_ENV
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+          tag: "${SANITIZED_BRANCH}-latest"
 
   build_and_push_latest_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-
     steps:
       - checkout
-      # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
-
-      # Build the Docker image
+      - docker-buildx/install
       - run:
-          name: Build Docker image
+          name: Build Application
           command: |
-            #Check for PR title Validity
-
-            IMAGE_TAG=$CIRCLE_TAG
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-            docker build -t openmf/ph-ee-connector-ams-mifos:latest .
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            fi
-      # Log in to DockerHub using environment variables
-      - run:
-          name: Login to DockerHub
-          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          tag: "latest"
 
-      # Push the Docker image to DockerHub
-      - run:
-          name: Push Docker image to DockerHub
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-            docker push openmf/ph-ee-connector-ams-mifos:latest
-            fi
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-            fi
 workflows:
   version: 2
-  build-and-push:
+  build-and-push-tags:
     jobs:
       - build_and_push_tag_image:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/  # Match tags in the format v1.2.3
+              only: /^v\d+\.\d+\.\d+$/
           context:
-              - DOCKER
+            - DOCKER
+  build-and-push-branches:
+    jobs:
+      - build_and_push_branch_image:
+          context:
+            - DOCKER
       - build_and_push_latest_image:
+          requires:
+            - build_and_push_branch_image
           context:
-              - DOCKER
+            - DOCKER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Build Application
           command: ./gradlew bootJar
       - docker-buildx/build-and-push:
-          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          image-name: "openmf/$CIRCLE_PROJECT_REPONAME" # Using repo name
           tag: "$CIRCLE_TAG"
 
   build_and_push_branch_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,11 @@
 version: 2.1
+orbs:
+  # Add your new orb
+  docker-buildx: devarsh/docker-buildx-orb@dev:first
 executors:
   docker-executor:
     docker:
       - image: circleci/openjdk:13.0-buster-node-browsers-legacy
-
-commands:
-  install-docker-buildx:
-    description: Install Docker Buildx
-    steps:
-      - run:
-          name: Install Docker Buildx
-          command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx version
-            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            # docker run --privileged --rm tonistiigi/binfmt --install arm64
-            docker context create buildcontext
-            docker buildx create buildcontext --use
 
 jobs:
   build_and_push_tag_image:
@@ -33,10 +19,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
-      - install-docker-buildx
+      - docker-buildx/install
       
       - run:
-          name: Build and Push Docker tag Image
+          name: Check if Docker image tag exists
           command: |
             # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
@@ -46,30 +32,14 @@ jobs:
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
-            
-            # Enable experimental Buildx feature
-            docker buildx ls
-            docker buildx create --use --name mybuilder || true
-            docker buildx inspect --bootstrap
-
-            # Log in to Docker Hub
-            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-
-            # Build and push the multi-architecture Docker image
-            ./gradlew bootJar
-            
-            docker buildx build  --push --platform linux/amd64,linux/arm64 \
-              -t "devarsh10/ph-ee-connector-ams-mifos:$IMAGE_TAG" \
-              . 
-            
-            # # Build and tag the Docker image
-            # ./gradlew bootJar
-            # docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
-
-            # # Push the Docker image to Docker Hub
-            # docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            # docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
-
+      
+      - run:
+          name: Build Application
+          command: ./gradlew bootJar
+          
+      - docker-buildx/build-and-push:
+          image-name: "devarsh10/ph-ee-connector-ams-mifos"
+          tag: "$CIRCLE_TAG-gazelle"
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -83,37 +53,17 @@ jobs:
       # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
-      - install-docker-buildx
+      - docker-buildx/install
 
-      # Log in to DockerHub using environment variables
       - run:
-          name: Login to DockerHub
-          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-          
-      # Build the Docker image
-      - run:
-          name: Build and Push Docker image
+          name: Build Application
           command: |
-            # Set environment variables
-            IMAGE_TAG=$CIRCLE_TAG
-            
-            # Check for PR title Validity  
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-
-            # Tag and push the docker image
-            docker buildx build --push --platform linux/amd64,linux/arm64 \
-            -t "devarsh10/ph-ee-connector-ams-mifos:latest" \
-            .
             
-            # docker build -t openmf/ph-ee-connector-ams-mifos:latest .
-            # if [ "$CIRCLE_BRANCH" != "master" ]; then
-            #   PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            #   PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            #   JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            #   if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-            #   docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            # fi
+      - docker-buildx/build-and-push:
+          image-name: "devarsh10/ph-ee-connector-ams-mifos"
+          tag: "latest"
       # # Log in to DockerHub using environment variables
       # - run:
       #     name: Login to DockerHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
           command: |
             # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
+            # I thought, this will be the best place to put this variable
+            IMAGE_NAME=$CIRCLE_PROJECT_NAME
 
             # Check if the Docker image with the same tag already exists in Docker Hub
             if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/devarsh10/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
@@ -39,8 +41,9 @@ jobs:
           command: ./gradlew bootJar
           
       - docker-buildx/build-and-push:
-          image-name: "devarsh10/ph-ee-connector-ams-mifos"
-          tag: "$CIRCLE_TAG-gazelle"
+          # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
+          image-name: "$IMAGE_NAME"
+          tag: "$IMAGE_TAG-gazelle"
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -63,7 +66,7 @@ jobs:
             ./gradlew clean bootJar
             
       - docker-buildx/build-and-push:
-          image-name: "devarsh10/ph-ee-connector-ams-mifos"
+          image-name: "$IMAGE_NAME"
           tag: "latest"
       # # Log in to DockerHub using environment variables
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
           
       - docker-buildx/build-and-push:
           # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
-          image-name: "$IMAGE_NAME"
-          tag: "$IMAGE_TAG"
+          image-name: $IMAGE_NAME
+          tag: $IMAGE_TAG
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -66,7 +66,7 @@ jobs:
             ./gradlew clean bootJar
             
       - docker-buildx/build-and-push:
-          image-name: "$IMAGE_NAME"
+          image-name: $IMAGE_NAME
           tag: "latest"
       # # Log in to DockerHub using environment variables
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 orbs:
   # Add your new orb
-  docker-buildx: devarsh/docker-buildx-orb@dev:first
+  docker-buildx: devarsh/docker-buildx-orb@0.1.1
+
 executors:
   docker-executor:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   # Add your new orb
-  docker-buildx: devarsh/docker-buildx-orb@0.1.1
+  docker-buildx: devarsh/docker-buildx-orb@dev:test
 
 executors:
   docker-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,53 @@
 version: 2.1
 orbs:
   docker-buildx: devarsh/docker-buildx-orb@0.1.1
-
 executors:
   docker-executor:
     docker:
       - image: circleci/openjdk:13.0-buster-node-browsers-legacy
-
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - run:
+          name: Set Lowercase Docker Image Vars
+          # Using tr for POSIX compatibility, could use ${VAR,,} with Bash 4+
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
       - docker-buildx/install
       - run:
           name: Check if Docker image tag exists
           command: |
             IMAGE_TAG=$CIRCLE_TAG
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tags/$IMAGE_TAG" > /dev/null; then
-              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
-              exit 0
+            # Using lowercase variables defined above
+            IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+            echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
+            # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
+              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
+              circleci-agent step halt
+            else
+              echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
             fi
       - run:
           name: Build Application
           command: ./gradlew bootJar
       - docker-buildx/build-and-push:
-          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
           tag: "$CIRCLE_TAG"
-
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
   build_and_push_branch_image:
     executor: docker-executor
     environment:
@@ -43,6 +57,13 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - run:
+          name: Set Lowercase Docker Image Vars
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
       - docker-buildx/install
       - run:
           name: Build Application
@@ -52,11 +73,14 @@ jobs:
       - run:
           name: Sanitize Branch Name
           command: |
-            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/\//-/g')" >> $BASH_ENV
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV # Also ensure branch tag is lowercase
       - docker-buildx/build-and-push:
-          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
           tag: "${SANITIZED_BRANCH}-latest"
-
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
   build_and_push_latest_image:
     executor: docker-executor
     environment:
@@ -66,6 +90,13 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - run:
+          name: Set Lowercase Docker Image Vars
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
       - docker-buildx/install
       - run:
           name: Build Application
@@ -73,26 +104,43 @@ jobs:
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
       - docker-buildx/build-and-push:
-          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
           tag: "latest"
-
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
 workflows:
   version: 2
-  build-and-push-tags:
+  build-and-push-pipeline:
     jobs:
+      # Build tags matching vX.Y.Z format
       - build_and_push_tag_image:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
           context:
             - DOCKER
-  build-and-push-branches:
-    jobs:
+      # Build any branch commit (except tags)
       - build_and_push_branch_image:
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /.*/
           context:
             - DOCKER
+      # Build 'latest' only when the branch image succeeds AND it's the main/master branch
       - build_and_push_latest_image:
           requires:
             - build_and_push_branch_image
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only:
+                - main # Or your primary branch name like 'master'
           context:
             - DOCKER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
 version: 2.1
-orbs:
-  # Add your new orb
-  docker-buildx: devarsh/docker-buildx-orb@dev:test
-
 executors:
   docker-executor:
     docker:
@@ -20,30 +16,26 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
-      - docker-buildx/install
-      
       - run:
-          name: Check if Docker image tag exists
+          name: Build and Push Docker tag Image
           command: |
             # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
-            # I thought, this will be the best place to put this variable
-            IMAGE_NAME=$CIRCLE_PROJECT_NAME
 
             # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/devarsh10/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
-      
-      - run:
-          name: Build Application
-          command: ./gradlew bootJar
-          
-      - docker-buildx/build-and-push:
-          # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
-          image-name: $CIRCLE_PROJECT_NAME
-          tag: $CIRCLE_TAG
+
+            # Build and tag the Docker image
+            ./gradlew bootJar
+            docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
+
+            # Push the Docker image to Docker Hub
+            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+            docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
+
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -57,35 +49,42 @@ jobs:
       # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
-      - docker-buildx/install
 
+      # Build the Docker image
       - run:
-          name: Build Application
+          name: Build Docker image
           command: |
+            #Check for PR title Validity
+
+            IMAGE_TAG=$CIRCLE_TAG
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-            
-      - docker-buildx/build-and-push:
-          image-name: $CIRCLE_PROJECT_NAME
-          tag: "latest"
-      # # Log in to DockerHub using environment variables
-      # - run:
-      #     name: Login to DockerHub
-      #     command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            docker build -t openmf/ph-ee-connector-ams-mifos:latest .
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
+              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
+            fi
+      # Log in to DockerHub using environment variables
+      - run:
+          name: Login to DockerHub
+          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
 
-      # # Push the Docker image to DockerHub
-      # - run:
-      #     name: Push Docker image to DockerHub
-      #     command: |
-      #       if [ "$CIRCLE_BRANCH" = "master" ]; then
-      #       docker push openmf/ph-ee-connector-ams-mifos:latest
-      #       fi
-      #       if [ "$CIRCLE_BRANCH" != "master" ]; then
-      #       PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-      #       PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-      #       JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-      #       docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-      #       fi
+      # Push the Docker image to DockerHub
+      - run:
+          name: Push Docker image to DockerHub
+          command: |
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            docker push openmf/ph-ee-connector-ams-mifos:latest
+            fi
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
+            fi
 workflows:
   version: 2
   build-and-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       # Then build and push with branch-version tag
       - docker-buildx/build-and-push:
           image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-          tag: "${SANITIZED_BRANCH}-${APP_VERSION}"
+          tag: "${SANITIZED_BRANCH}-${CIRCLE_TAG}"
           # Add dockerhub credentials if needed
           # dockerhub-username: "$DOCKERHUB_USERNAME"
           # dockerhub-password: "$DOCKERHUB_PASSWORD"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,23 @@ executors:
     docker:
       - image: circleci/openjdk:13.0-buster-node-browsers-legacy
 
+commands:
+  install-docker-buildx:
+    description: Install Docker Buildx
+    steps:
+      - run:
+          name: Install Docker Buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            # docker run --privileged --rm tonistiigi/binfmt --install arm64
+            docker context create buildcontext
+            docker buildx create buildcontext --use
+
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
@@ -16,6 +33,8 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - install-docker-buildx
+      
       - run:
           name: Build and Push Docker tag Image
           command: |
@@ -23,18 +42,33 @@ jobs:
             IMAGE_TAG=$CIRCLE_TAG
 
             # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/devarsh10/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
+            
+            # Enable experimental Buildx feature
+            docker buildx ls
+            docker buildx create --use --name mybuilder || true
+            docker buildx inspect --bootstrap
 
-            # Build and tag the Docker image
+            # Log in to Docker Hub
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+            # Build and push the multi-architecture Docker image
             ./gradlew bootJar
-            docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
+            
+            docker buildx build  --push --platform linux/amd64,linux/arm64 \
+              -t "devarsh10/ph-ee-connector-ams-mifos:$IMAGE_TAG" \
+              . 
+            
+            # # Build and tag the Docker image
+            # ./gradlew bootJar
+            # docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
 
-            # Push the Docker image to Docker Hub
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
+            # # Push the Docker image to Docker Hub
+            # docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+            # docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
 
           # when: always  # The job will be executed even if there's no match for the tag filter
 
@@ -49,42 +83,55 @@ jobs:
       # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
+      - install-docker-buildx
 
-      # Build the Docker image
-      - run:
-          name: Build Docker image
-          command: |
-            #Check for PR title Validity
-
-            IMAGE_TAG=$CIRCLE_TAG
-            ./gradlew checkstyleMain
-            ./gradlew clean bootJar
-            docker build -t openmf/ph-ee-connector-ams-mifos:latest .
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            fi
       # Log in to DockerHub using environment variables
       - run:
           name: Login to DockerHub
           command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-
-      # Push the Docker image to DockerHub
+          
+      # Build the Docker image
       - run:
-          name: Push Docker image to DockerHub
+          name: Build and Push Docker image
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-            docker push openmf/ph-ee-connector-ams-mifos:latest
-            fi
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-            fi
+            # Set environment variables
+            IMAGE_TAG=$CIRCLE_TAG
+            
+            # Check for PR title Validity  
+            ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+
+            # Tag and push the docker image
+            docker buildx build --push --platform linux/amd64,linux/arm64 \
+            -t "devarsh10/ph-ee-connector-ams-mifos:latest" \
+            .
+            
+            # docker build -t openmf/ph-ee-connector-ams-mifos:latest .
+            # if [ "$CIRCLE_BRANCH" != "master" ]; then
+            #   PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+            #   PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+            #   JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+            #   if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
+            #   docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
+            # fi
+      # # Log in to DockerHub using environment variables
+      # - run:
+      #     name: Login to DockerHub
+      #     command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+
+      # # Push the Docker image to DockerHub
+      # - run:
+      #     name: Push Docker image to DockerHub
+      #     command: |
+      #       if [ "$CIRCLE_BRANCH" = "master" ]; then
+      #       docker push openmf/ph-ee-connector-ams-mifos:latest
+      #       fi
+      #       if [ "$CIRCLE_BRANCH" != "master" ]; then
+      #       PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+      #       PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+      #       JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+      #       docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
+      #       fi
 workflows:
   version: 2
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:13
+FROM openjdk:17
 EXPOSE 5000
 
 COPY build/libs/*.jar .

--- a/src/main/java/org/mifos/connector/ams/interop/AmsCommonService.java
+++ b/src/main/java/org/mifos/connector/ams/interop/AmsCommonService.java
@@ -4,6 +4,7 @@ import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.HTTP_PATH;
 import static org.mifos.connector.ams.camel.config.CamelProperties.TRANSFER_ACTION;
 import static org.mifos.connector.ams.camel.cxfrs.HeaderBasedInterceptor.CXF_TRACE_HEADER;
+import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_HOLDING_INSTITUTION_ID;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_NUMBER;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.PARTY_ID;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.PARTY_ID_TYPE;
@@ -118,7 +119,9 @@ public class AmsCommonService {
         headers.put(HTTP_PATH, amsLoanRepaymentPath.replace("{accountNumber}", e.getProperty(ACCOUNT_NUMBER, String.class)));
         logger.debug("Loan Repayment Body: {}", e.getIn().getBody());
         headers.put("Content-Type", APPLICATION_TYPE);
-        headers.putAll(tenantService.getHeaders(e.getProperty(TENANT_ID, String.class)));
+        Map<String, Object> variables = e.getProperty("zeebeVariables", Map.class);
+        String accountHoldingInstitutionId = (String) variables.get(ACCOUNT_HOLDING_INSTITUTION_ID);
+        headers.putAll(tenantService.getHeaders(accountHoldingInstitutionId));
         if (isAmsLocalEnabled) {
             cxfrsUtil.sendInOut("cxfrs:bean:ams.local.loan", e, headers, e.getIn().getBody());
         } else {

--- a/src/main/java/org/mifos/connector/ams/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/ams/zeebe/ZeebeVariables.java
@@ -24,6 +24,7 @@ public final class ZeebeVariables {
     public static final String QUOTE_SWITCH_REQUEST = "quoteSwitchRequest";
     public static final String QUOTE_SWITCH_REQUEST_AMOUNT = "quoteSwitchRequestAmount";
     public static final String TENANT_ID = "tenantId";
+    public static final String ACCOUNT_HOLDING_INSTITUTION_ID = "accountHoldingInstitutionId";
     public static final String BOOK_TRANSACTION_ID = "bookTransactionId";
     public static final String TRANSACTION_ID = "transactionId";
     public static final String TRANSFER_CODE = "transferCode";

--- a/src/main/java/org/mifos/connector/ams/zeebe/ZeebeeWorkers.java
+++ b/src/main/java/org/mifos/connector/ams/zeebe/ZeebeeWorkers.java
@@ -10,6 +10,7 @@ import static org.mifos.connector.ams.zeebe.ZeebeUtil.zeebeVariable;
 import static org.mifos.connector.ams.zeebe.ZeebeUtil.zeebeVariablesToCamelProperties;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_CURRENCY;
+import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_HOLDING_INSTITUTION_ID;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_IDENTIFIER;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.ACCOUNT_NUMBER;
 import static org.mifos.connector.ams.zeebe.ZeebeVariables.BOOK_TRANSACTION_ID;
@@ -410,11 +411,11 @@ public class ZeebeeWorkers {
                     Map<String, Object> existingVariables = job.getVariablesAsMap();
                     logger.debug("Exisiting variables {}", existingVariables);
 
-                    String tenantId = (String) existingVariables.get(TENANT_ID);
-
+                    String accountHoldingInstitutionId = (String) existingVariables.get(ACCOUNT_HOLDING_INSTITUTION_ID);
                     Exchange ex = new DefaultExchange(camelContext);
                     Map<String, Object> variables = job.getVariablesAsMap();
-                    zeebeVariablesToCamelProperties(variables, ex, TRANSACTION_ID, TENANT_ID, CHANNEL_REQUEST);
+                    zeebeVariablesToCamelProperties(variables, ex, TRANSACTION_ID, accountHoldingInstitutionId, CHANNEL_REQUEST);
+
                     ex.setProperty(TRANSFER_ACTION, CREATE.name());
                     ex.setProperty("payeeTenantId", existingVariables.get("payeeTenantId"));
                     ex.setProperty(ZEEBE_JOB_KEY, job.getKey());
@@ -440,7 +441,7 @@ public class ZeebeeWorkers {
                     logWorkerDetails(job);
                     Map<String, Object> existingVariables = job.getVariablesAsMap();
                     logger.debug("Exisiting variables {}", existingVariables);
-                    String accountHoldingInstitutionId = (String) existingVariables.get(TENANT_ID);
+                    String accountHoldingInstitutionId = (String) existingVariables.get(ACCOUNT_HOLDING_INSTITUTION_ID);
                     Exchange ex = new DefaultExchange(camelContext);
                     Map<String, Object> variables = job.getVariablesAsMap();
                     GsmaTransfer gsmaTransfer = objectMapper.readValue((String) variables.get(CHANNEL_REQUEST), GsmaTransfer.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,7 @@ server:
 management:
   endpoint:
     health:
+      enabled: true
       probes:
         enabled: true
       liveness:

--- a/tomtest.txt
+++ b/tomtest.txt
@@ -1,0 +1,2 @@
+this is simply to trigger the pipleine
+


### PR DESCRIPTION
## Description

* Add a link to the Jira ticket -> https://mifosforge.jira.com/browse/GAZ-12
* Describe the changes made and why they were made.
  * Here, we have added the docker buildx support.
  * Which will make sure that the image pushed, will support multi-architecture[`amd64`, `arm64`].
  * Also, keeping in mind that, one can deploy the whole project locally and build & test the circleci pipeline associated with their circleCI account, instead of getting the authorization access from openMF.
  
I hope I am able to make all the points clear.
Thank you

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above.

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
