### PR TITLE
[GAZ-12] add docker branch push along with tag and latest push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  docker-buildx: devarsh/docker-buildx-orb@0.1.1
+
 executors:
   docker-executor:
     docker:
@@ -10,91 +13,86 @@ jobs:
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-      GITHUB_TOKEN: ${GITHUB_TOKEN}  # Add the GitHub token as an environment variable
-
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
+      - docker-buildx/install
       - run:
-          name: Build and Push Docker tag Image
+          name: Check if Docker image tag exists
           command: |
-            # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
-
-            # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tags/$IMAGE_TAG" > /dev/null; then
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
+      - run:
+          name: Build Application
+          command: ./gradlew bootJar
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          tag: "$CIRCLE_TAG"
 
-            # Build and tag the Docker image
-            ./gradlew bootJar
-            docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
-
-            # Push the Docker image to Docker Hub
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
-
-          # when: always  # The job will be executed even if there's no match for the tag filter
+  build_and_push_branch_image:
+    executor: docker-executor
+    environment:
+      JVM_OPTS: -Xmx512m
+      TERM: dumb
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - docker-buildx/install
+      - run:
+          name: Build Application
+          command: |
+            ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+      - run:
+          name: Sanitize Branch Name
+          command: |
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/\//-/g')" >> $BASH_ENV
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+          tag: "${SANITIZED_BRANCH}-latest"
 
   build_and_push_latest_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-
     steps:
       - checkout
-      # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
-
-      # Build the Docker image
+      - docker-buildx/install
       - run:
-          name: Build Docker image
+          name: Build Application
           command: |
-            #Check for PR title Validity
-
-            IMAGE_TAG=$CIRCLE_TAG
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-            docker build -t openmf/ph-ee-connector-ams-mifos:latest .
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            fi
-      # Log in to DockerHub using environment variables
-      - run:
-          name: Login to DockerHub
-          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+      - docker-buildx/build-and-push:
+          image-name: "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" # Using repo name
+          tag: "latest"
 
-      # Push the Docker image to DockerHub
-      - run:
-          name: Push Docker image to DockerHub
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-            docker push openmf/ph-ee-connector-ams-mifos:latest
-            fi
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-            fi
 workflows:
   version: 2
-  build-and-push:
+  build-and-push-tags:
     jobs:
       - build_and_push_tag_image:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/  # Match tags in the format v1.2.3
+              only: /^v\d+\.\d+\.\d+$/
           context:
-              - DOCKER
+            - DOCKER
+  build-and-push-branches:
+    jobs:
+      - build_and_push_branch_image:
+          context:
+            - DOCKER
       - build_and_push_latest_image:
+          requires:
+            - build_and_push_branch_image
           context:
-              - DOCKER
+            - DOCKER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
 version: 2.1
-orbs:
-  # Add your new orb
-  docker-buildx: devarsh/docker-buildx-orb@dev:test
-
 executors:
   docker-executor:
     docker:
@@ -20,30 +16,26 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.24
-      - docker-buildx/install
-      
       - run:
-          name: Check if Docker image tag exists
+          name: Build and Push Docker tag Image
           command: |
             # Set environment variables
             IMAGE_TAG=$CIRCLE_TAG
-            # I thought, this will be the best place to put this variable
-            IMAGE_NAME=$CIRCLE_PROJECT_NAME
 
             # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/devarsh10/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-connector-ams-mifos/tags/$IMAGE_TAG" > /dev/null; then
               echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
               exit 0
             fi
-      
-      - run:
-          name: Build Application
-          command: ./gradlew bootJar
-          
-      - docker-buildx/build-and-push:
-          # image-name: "devarsh10/ph-ee-connector-ams-mifos" configure this variable in CircleCI
-          image-name: $CIRCLE_PROJECT_NAME
-          tag: $CIRCLE_TAG
+
+            # Build and tag the Docker image
+            ./gradlew bootJar
+            docker build -t "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG" .
+
+            # Push the Docker image to Docker Hub
+            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+            docker push "openmf/ph-ee-connector-ams-mifos:$IMAGE_TAG"
+
           # when: always  # The job will be executed even if there's no match for the tag filter
 
   build_and_push_latest_image:
@@ -57,35 +49,42 @@ jobs:
       # Install Docker to build and push the image
       - setup_remote_docker:
           version: 20.10.24
-      - docker-buildx/install
 
+      # Build the Docker image
       - run:
-          name: Build Application
+          name: Build Docker image
           command: |
+            #Check for PR title Validity
+
+            IMAGE_TAG=$CIRCLE_TAG
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-            
-      - docker-buildx/build-and-push:
-          image-name: $CIRCLE_PROJECT_NAME
-          tag: "latest"
-      # # Log in to DockerHub using environment variables
-      # - run:
-      #     name: Login to DockerHub
-      #     command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+            docker build -t openmf/ph-ee-connector-ams-mifos:latest .
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
+              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
+            fi
+      # Log in to DockerHub using environment variables
+      - run:
+          name: Login to DockerHub
+          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
 
-      # # Push the Docker image to DockerHub
-      # - run:
-      #     name: Push Docker image to DockerHub
-      #     command: |
-      #       if [ "$CIRCLE_BRANCH" = "master" ]; then
-      #       docker push openmf/ph-ee-connector-ams-mifos:latest
-      #       fi
-      #       if [ "$CIRCLE_BRANCH" != "master" ]; then
-      #       PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-      #       PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-      #       JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-      #       docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-      #       fi
+      # Push the Docker image to DockerHub
+      - run:
+          name: Push Docker image to DockerHub
+          command: |
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            docker push openmf/ph-ee-connector-ams-mifos:latest
+            fi
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
+            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
+            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
+            fi
 workflows:
   version: 2
   build-and-push:


### PR DESCRIPTION
## Description

* Describe the changes made and why they were made: 
  *  Now, we can see the following list of tags in DockerHub once the pipeline is triggered and ran successfully.
![Screenshot 2025-04-09 105443](https://github.com/user-attachments/assets/a20036e7-4860-45a1-a7a4-a18d7eae2e09)

  * The major changes are configuring the environmental variables only. Now, in total the developer will need to configure this env variable to make the pipeline run successfully.
`CIRCLE_BRANCH`, `CIRCLE_PROJECT_NAME`, `CIRCLE_TAG`, `DOCKERHUB_PASSWORD`, `DOCKERHUB_USERNAME`, `GITHUB_TOKEN`.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above.

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
